### PR TITLE
change chat request response_format.json_schema.schema to json.RawMes…

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -285,10 +285,10 @@ type ChatCompletionResponseFormat struct {
 }
 
 type ChatCompletionResponseFormatJSONSchema struct {
-	Name        string         `json:"name"`
-	Description string         `json:"description,omitempty"`
-	Schema      json.Marshaler `json:"schema"`
-	Strict      bool           `json:"strict"`
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Schema      json.RawMessage `json:"schema"`
+	Strict      bool            `json:"strict"`
 }
 
 // ChatCompletionRequest represents a request structure for chat completion API.


### PR DESCRIPTION
fix: cannot unmarshal object into Go struct field ChatCompletionResponseFormatJSONSchema.response_format.json_schema.schema of type json.Marshaler

change chat request response_format.json_schema.schema to json.RawMessage